### PR TITLE
Allow setting of a custom substitute character for sanitizeFileName()

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -58,6 +58,13 @@ class Handler implements UploadHandlerInterface
     protected $validator;
 
     /**
+     * The character replacement used in sanitizing file names
+     *
+     * @var string
+     */
+    private $substitute = '_';
+
+    /**
      * @param $directoryOrContainer
      * @param ErrorMessage $errorMessagePrototype
      * @param array $options
@@ -186,6 +193,15 @@ class Handler implements UploadHandlerInterface
     }
 
     /**
+     *
+     * @param unknown $char
+     */
+    public function setSubstitute($char)
+    {
+        $this->substitute = $char;
+    }
+
+    /**
      * Processes a single uploaded file
      * - sanitize the name
      * - validates the file
@@ -262,6 +278,6 @@ class Handler implements UploadHandlerInterface
      */
     protected function sanitizeFileName($name)
     {
-        return preg_replace('/[^A-Za-z0-9\.]+/', '_', $name);
+        return preg_replace('/[^A-Za-z0-9\.]+/', $this->substitute, $name);
     }
 }


### PR DESCRIPTION
### Use case
When using `Sirius\Upload\Handler` it is more simplistic to — optionally — set the replacement character rather than implement a new class that extends it, just to have one function behave slightly differently.

