### PR TITLE
change prefix directory permissions

### DIFF
--- a/src/Container/Local.php
+++ b/src/Container/Local.php
@@ -23,7 +23,13 @@ class Local implements ContainerInterface
     protected function ensureDirectory($directory)
     {
         if (!is_dir($directory)) {
-            mkdir($directory, 0766, true);
+            /**
+             * change prefix directory from 766 to 755:
+             * 755 is the way to go because the User need the execute flag to enter the directory.
+             * Same issue with 766 if the Web user is either Group or Others. 6 = read/write and lack the execute flag.
+             * So 766 wont work if the web server is not the owner of the directory.
+            */
+            mkdir($directory, 0755, true); // , because it dosent work 
         }
 
         return is_dir($directory) && $this->isWritable();

--- a/src/Container/Local.php
+++ b/src/Container/Local.php
@@ -29,7 +29,7 @@ class Local implements ContainerInterface
              * Same issue with 766 if the Web user is either Group or Others. 6 = read/write and lack the execute flag.
              * So 766 wont work if the web server is not the owner of the directory.
             */
-            mkdir($directory, 0755, true); // , because it dosent work 
+            mkdir($directory, 0755, true);
         }
 
         return is_dir($directory) && $this->isWritable();


### PR DESCRIPTION
## change prefix directory from 766 to 755:
755 is the way to go because the User need the execute flag to enter the directory.
Same issue with 766 if the Web user is either Group or Others. 6 = read/write and lack the execute flag.
So 766 wont work if the web server is not the owner of the directory.