### PR TITLE
Fix incorrect parameter and typos in example code.

### DIFF
--- a/docs/simple_example.md
+++ b/docs/simple_example.md
@@ -14,8 +14,8 @@ $uploadHandler = new UploadHandler('/path/to/local_folder');
 
 // set up the validation rules
 $uploadHandler->addRule('extension', ['allowed' => 'jpg', 'jpeg', 'png'], '{label} should be a valid image (jpg, jpeg, png)', 'Profile picture');
-$uploadHandler->addRule('size', ['max' => '20M'], '{label} should have less than {max}', 'Profile picture');
-$uploadHandler->addRule('imageratio', ['ratio' => 1], '{label} should be a sqare image', 'Profile picture');
+$uploadHandler->addRule('size', ['size' => '20M'], '{label} should be less than {size}', 'Profile picture');
+$uploadHandler->addRule('imageratio', ['ratio' => 1], '{label} should be a square image', 'Profile picture');
 
 ```
 


### PR DESCRIPTION
I had followed the example code and couldn't work out why the size rule wasn't working. It turns out there is no `max` option, instead it should be `size`.

Maybe there should also be some kind of warning issued when an invalid option is supplied. The silent failure made it difficult to debug.