### PR TITLE
[Feature] Add `$file` argument in `SanitizerCallback`.

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -228,7 +228,7 @@ class Handler implements UploadHandlerInterface
         $file['original_name'] = $file['name'];
 
         // sanitize the file name
-        $file['name'] = $this->sanitizeFileName($file['name']);
+        $file['name'] = $this->sanitizeFileName($file['name'], $file);
 
         $file = $this->validateFile($file);
         // if there are messages the file is not valid
@@ -289,12 +289,13 @@ class Handler implements UploadHandlerInterface
      * and replacing "invalid" characters with underscore _
      *
      * @param  string $name
+     * @param  array $file
      * @return string
      */
-    protected function sanitizeFileName($name)
+    protected function sanitizeFileName($name, $file)
     {
         if ($this->sanitizerCallback) {
-            return call_user_func($this->sanitizerCallback, $name);
+            return call_user_func($this->sanitizerCallback, $name, $file);
         }
         return preg_replace('/[^A-Za-z0-9\.]+/', '_', $name);
     }

--- a/tests/src/HandlerTest.php
+++ b/tests/src/HandlerTest.php
@@ -288,8 +288,11 @@ class HandlerTest extends \PHPUnit\Framework\TestCase
 
     function testCustomSanitizationCallback()
     {
-        $this->handler->setSanitizerCallback(function ($name) {
-            return preg_replace('/[^A-Za-z0-9\.]+/', '-', strtolower($name));
+        $this->handler->setSanitizerCallback(function ($name, $file) {
+            return preg_replace(
+                '/[^A-Za-z0-9\.]+/', '-',
+                substr(md5_file($file['tmp_name']), 0, 8) . '-' . strtolower($name)
+            );
         });
         $this->createTemporaryFile('ABC 123.tmp', 'non image file');
 
@@ -300,7 +303,7 @@ class HandlerTest extends \PHPUnit\Framework\TestCase
             )
         );
 
-        $this->assertTrue(file_exists($this->uploadFolder . '/abc-123.tmp'));
+        $this->assertTrue(file_exists($this->uploadFolder . '/35d41ded-abc-123.tmp'));
     }
 
     function testExceptionThrownForInvalidSanitizationCallback()


### PR DESCRIPTION
Add `$file` argument in `SanitizerCallback`.  
For compute and rename to hash file name.